### PR TITLE
fix: 특정 비율의 이미지가 회전되어 리사이징 되는 문제를 해결하는 구문 추가

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,6 +58,7 @@ exports.handler = async (event, _, callback) => {
   async function resizeImage(image, folder) {
     try {
         const resizedImage = await sharp(image.Body)
+        .rotate()
         .resize({ 
             width: folder.width,
             height: folder.height,


### PR DESCRIPTION
- 수정이유: 이미지 등록시 리사이징 된 이미지가 회전되어 저장되는 경우를 발견하여 이를 해결하기 위한 수정
- 문제 원인
  - 이미지가 회전되는 이유는 이미지 파일에 포함된 메타데이터(EXIF 데이터)에 방향 정보가 포함되어 있기 때문
  - sharp 라이브러리에서 이를 자동으로 처리하기 때문에 회전이 발생함을 확인
- 문제해결
  - 작성된 모듈의 resizeImage 메서드에 rotate() 메서드를 적용하여 EXIF 데이터를 무시하고 이미지의 방향을 지정
  - rotate() 메서드에 특정 값을 전달하지 않으면, 자동으로 회전을 해제하기 때문에 이를 적용